### PR TITLE
'Dockerfile' simplification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY tests/ ./tests/
 
 WORKDIR build
 
-RUN cmake -G "CodeBlocks - Unix Makefiles" .. && \
+RUN cmake .. && \
     cmake --build . --target all -- -j 2
 
 CMD ["./bin/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,4 @@ WORKDIR build
 RUN cmake -G "CodeBlocks - Unix Makefiles" .. && \
     cmake --build . --target all -- -j 2
 
-RUN ./bin/main && \
-    lcov --directory . --capture --output-file coverage.info && \
-    lcov --remove coverage.info '/usr/*' \
-                                '/opt/cauldron/tests/*' \
-                                '/root/.conan/*' \
-                                --output-file coverage.info && \
-    lcov --list coverage.info
-
 CMD ["./bin/main"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -ex
 
 conan install ..
-cmake -G "CodeBlocks - Unix Makefiles" .
+cmake ..
 cmake --build . --target all -- -j 2
 
 ./bin/main


### PR DESCRIPTION
Removing generating coverage info from 'Dockerfile' to make builds faster.